### PR TITLE
feat: add properties route with loading/error states and HomeNav component

### DIFF
--- a/nextjs-project/app/about/page.tsx
+++ b/nextjs-project/app/about/page.tsx
@@ -43,7 +43,7 @@ export default async function AboutPage() {
   const hasContent = about.title !== null || about.blocks.length > 0;
 
   return (
-    <main className="py-16 md:py-24">
+    <main className="pt-24 pb-16 md:pt-28 md:pb-24">
       <div className="mx-auto max-w-7xl px-6">
         {about.title && (
           <h1 className="font-display text-primary text-4xl md:text-5xl lg:text-6xl leading-tight mb-8 md:mb-12">

--- a/nextjs-project/app/contact/page.tsx
+++ b/nextjs-project/app/contact/page.tsx
@@ -26,7 +26,7 @@ export async function generateMetadata(): Promise<Metadata> {
 
 export default function ContactPage() {
   return (
-    <div className="mx-auto max-w-lg px-4 py-8 sm:py-10 md:py-14 lg:py-16">
+    <div className="mx-auto max-w-lg px-4 pt-24 pb-8 sm:pt-24 sm:pb-10 md:pt-28 md:pb-14 lg:pt-32 lg:pb-16">
       {/* Heading */}
       <div className="mb-8 text-center">
         <h1 className="font-display text-[--color-primary] text-3xl sm:text-4xl md:text-5xl leading-tight">

--- a/nextjs-project/app/globals.css
+++ b/nextjs-project/app/globals.css
@@ -26,6 +26,12 @@
     0 0 10px 0 rgba(255, 255, 255, 0.05) inset;
 }
 
+/* Animations — inherited from The Monolith reference */
+@keyframes slideUp {
+  from { transform: translateY(100%); opacity: 0; }
+  to { transform: translateY(0); opacity: 1; }
+}
+
 /* Dark-mode-only base styles */
 body {
   background-color: var(--color-background);

--- a/nextjs-project/app/layout.tsx
+++ b/nextjs-project/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { Playfair_Display, Inter } from "next/font/google";
-import { Navbar } from "@/components/Navbar";
+import { ConditionalNavbar } from "@/components/ConditionalNavbar";
 import { Footer } from "@/components/Footer";
 import "./globals.css";
 
@@ -33,8 +33,8 @@ export default function RootLayout({
       className={`${playfair.variable} ${inter.variable} antialiased`}
     >
       <body className="bg-background text-secondary font-sans min-h-screen flex flex-col">
-        <Navbar />
-        <main className="flex-1 pt-24">{children}</main>
+        <ConditionalNavbar />
+        <main className="flex-1">{children}</main>
         <Footer />
       </body>
     </html>

--- a/nextjs-project/app/page.test.tsx
+++ b/nextjs-project/app/page.test.tsx
@@ -1,12 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen } from "@testing-library/react";
-import type { Property } from "@/lib/schemas/property";
+import { render, screen, cleanup } from "@testing-library/react";
 import type { Global } from "@/lib/schemas/global";
-import type { StrapiMedia } from "@/lib/schemas/strapi";
 
-// Mock the fetch functions used by the Server Component
-vi.mock("@/lib/fetch-property", () => ({
-  fetchProperties: vi.fn(),
+// Mock the child components
+vi.mock("@/components/MonolithHero", () => ({
+  MonolithHero: ({ tagline }: { tagline: string }) => (
+    <div data-testid="monolith-hero">
+      <span data-testid="hero-tagline">{tagline}</span>
+    </div>
+  ),
 }));
 
 vi.mock("@/lib/fetch-global", () => ({
@@ -17,92 +19,12 @@ vi.mock("@/lib/env", () => ({
   getEnv: () => ({ STRAPI_URL: "http://localhost:1337" }),
 }));
 
-// Mock Next.js Image to render as a regular img for testing
-vi.mock("next/image", () => ({
-  default: (props: {
-    src: string;
-    alt: string;
-    fill?: boolean;
-    priority?: boolean;
-    sizes?: string;
-    className?: string;
-  }) => (
-    <img
-      src={props.src}
-      alt={props.alt}
-      data-nimg={props.fill ? "fill" : undefined}
-      className={props.className}
-    />
-  ),
-}));
-
-// Mock Next.js Link
-vi.mock("next/link", () => ({
-  default: ({
-    href,
-    children,
-    className,
-  }: {
-    href: string;
-    children: React.ReactNode;
-    className?: string;
-  }) => (
-    <a href={href} className={className}>
-      {children}
-    </a>
-  ),
-}));
-
-// Import after mocking
-import { fetchProperties } from "@/lib/fetch-property";
 import { fetchGlobal } from "@/lib/fetch-global";
 
-// Dynamic import of the page component
 const HomePage = async () => {
   const { default: Page } = await import("./page");
   return Page;
 };
-
-function createMedia(overrides: Partial<StrapiMedia> = {}): StrapiMedia {
-  return {
-    id: 1,
-    documentId: "media-001",
-    url: "/uploads/hero.jpg",
-    alternativeText: "Hero image",
-    name: "hero.jpg",
-    width: 1920,
-    height: 1080,
-    formats: null,
-    mime: "image/jpeg",
-    size: 204800,
-    ...overrides,
-  };
-}
-
-function createProperty(overrides: Partial<Property> = {}): Property {
-  return {
-    id: 1,
-    documentId: "prop-001",
-    title: "Sunset Valley Ranch",
-    slug: "sunset-valley-ranch",
-    location: "Austin, Texas",
-    acreage: 500,
-    propertyType: "ranch",
-    description: null,
-    heroImage: createMedia(),
-    heroVideo: null,
-    gallery: [
-      createMedia({ id: 2, documentId: "media-002", url: "/uploads/gallery1.jpg" }),
-      createMedia({ id: 3, documentId: "media-003", url: "/uploads/gallery2.jpg" }),
-    ],
-    mapImage: null,
-    status: "published",
-    publishedAt: "2026-04-01T00:00:00.000Z",
-    createdAt: "2026-04-01T00:00:00.000Z",
-    updatedAt: "2026-04-01T00:00:00.000Z",
-    ...overrides,
-  };
-}
 
 function createGlobal(overrides: Partial<Global> = {}): Global {
   return {
@@ -126,107 +48,19 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
-  vi.unstubAllEnvs();
+  cleanup();
 });
 
-describe("HomePage (Server Component)", () => {
-  it("renders hero section with property title", async () => {
-    vi.mocked(fetchProperties).mockResolvedValue([createProperty()]);
+describe("HomePage (brand splash)", () => {
+  it("renders MonolithHero", async () => {
     vi.mocked(fetchGlobal).mockResolvedValue(createGlobal());
 
     const Page = await HomePage();
     const result = await Page();
     render(result);
 
-    expect(
-      screen.getByRole("heading", { name: /sunset valley ranch/i }),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("monolith-hero")).toBeInTheDocument();
   });
 
-  it("renders View Details link with correct slug", async () => {
-    vi.mocked(fetchProperties).mockResolvedValue([createProperty()]);
-    vi.mocked(fetchGlobal).mockResolvedValue(createGlobal());
 
-    const Page = await HomePage();
-    const result = await Page();
-    render(result);
-
-    const link = screen.getByRole("link", { name: /view details/i });
-    expect(link).toHaveAttribute("href", "/properties/sunset-valley-ranch");
-  });
-
-  it("renders gallery preview when gallery images exist", async () => {
-    vi.mocked(fetchProperties).mockResolvedValue([createProperty()]);
-    vi.mocked(fetchGlobal).mockResolvedValue(createGlobal());
-
-    const Page = await HomePage();
-    const result = await Page();
-    render(result);
-
-    expect(
-      screen.getByRole("heading", { name: /gallery preview/i }),
-    ).toBeInTheDocument();
-  });
-
-  it("renders CTA section", async () => {
-    vi.mocked(fetchProperties).mockResolvedValue([createProperty()]);
-    vi.mocked(fetchGlobal).mockResolvedValue(createGlobal());
-
-    const Page = await HomePage();
-    const result = await Page();
-    render(result);
-
-    expect(
-      screen.getByRole("heading", { name: /interested/i }),
-    ).toBeInTheDocument();
-  });
-
-  it("handles empty properties gracefully", async () => {
-    vi.mocked(fetchProperties).mockResolvedValue([]);
-    vi.mocked(fetchGlobal).mockResolvedValue(createGlobal());
-
-    const Page = await HomePage();
-    const result = await Page();
-    render(result);
-
-    // Should not have hero section content
-    expect(
-      screen.queryByRole("heading", { name: /sunset valley ranch/i }),
-    ).not.toBeInTheDocument();
-  });
-
-  it("handles property with null gallery", async () => {
-    vi.mocked(fetchProperties).mockResolvedValue([
-      createProperty({ gallery: null }),
-    ]);
-    vi.mocked(fetchGlobal).mockResolvedValue(createGlobal());
-
-    const Page = await HomePage();
-    const result = await Page();
-    render(result);
-
-    // Gallery heading should still show (with "no images" message)
-    expect(
-      screen.getByRole("heading", { name: /gallery preview/i }),
-    ).toBeInTheDocument();
-  });
-
-  it("handles property with null heroImage", async () => {
-    vi.mocked(fetchProperties).mockResolvedValue([
-      createProperty({ heroImage: null }),
-    ]);
-    vi.mocked(fetchGlobal).mockResolvedValue(createGlobal());
-
-    const Page = await HomePage();
-    const result = await Page();
-    render(result);
-
-    // Title and CTA should still render
-    expect(
-      screen.getByRole("heading", { name: /sunset valley ranch/i }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("link", { name: /view details/i }),
-    ).toBeInTheDocument();
-  });
 });

--- a/nextjs-project/app/page.tsx
+++ b/nextjs-project/app/page.tsx
@@ -1,10 +1,7 @@
 import type { Metadata } from "next";
-import { fetchProperties } from "@/lib/fetch-property";
 import { fetchGlobal } from "@/lib/fetch-global";
 import { getEnv } from "@/lib/env";
-import { HeroSection } from "@/components/HeroSection";
-import { GalleryPreview } from "@/components/GalleryPreview";
-import { CtaSection } from "@/components/CtaSection";
+import { MonolithHero } from "@/components/MonolithHero";
 
 /** Render at request time — Strapi may not be available during build. */
 export const dynamic = "force-dynamic";
@@ -29,38 +26,21 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 /**
- * Homepage — async Server Component.
- * Fetches the first published property from Strapi and renders
- * it as a fullscreen hero with gallery preview and CTA.
+ * Homepage — brand splash / enter page.
+ *
+ * Adapted from the "Monolith" reference design:
+ *   - Fullscreen hero with glass overlay
+ *   - Animated centered content (tagline → headline → description → CTA)
+ *   - Side brand mark
+ *
+ * Pure brand presentation. No property data.
  */
 export default async function Home() {
-  const properties = await fetchProperties();
-  const featured = properties[0] ?? null;
-
-  if (!featured) {
-    return (
-      <div className="flex min-h-[60vh] flex-col items-center justify-center gap-6 px-6 text-center">
-        <h1 className="font-display text-primary text-4xl md:text-6xl leading-tight">
-          Welcome to Zenith
-        </h1>
-        <p className="text-secondary/70 text-lg font-sans max-w-lg">
-          Our property portfolio is being updated. Check back soon for
-          exceptional listings.
-        </p>
-      </div>
-    );
-  }
-
-  const { STRAPI_URL: strapiUrl } = getEnv();
-  const galleryImages = featured.gallery ?? [];
+  const globalData = await fetchGlobal();
 
   return (
-    <>
-      <HeroSection property={featured} strapiUrl={strapiUrl} />
-
-      <GalleryPreview images={galleryImages} strapiUrl={strapiUrl} />
-
-      <CtaSection />
-    </>
+    <div className="fixed inset-0 z-[60] bg-background overflow-hidden">
+      <MonolithHero />
+    </div>
   );
 }

--- a/nextjs-project/app/properties/error.tsx
+++ b/nextjs-project/app/properties/error.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+/**
+ * Error boundary for the properties listing route.
+ * Automatically used by Next.js when a Server Component throws.
+ * Must be a Client Component to handle the reset() interaction.
+ */
+export default function PropertiesError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center gap-6 px-6 text-center">
+      <h2 className="font-display text-4xl text-primary">
+        Unable to load properties
+      </h2>
+      <p className="max-w-md text-secondary/70">{error.message}</p>
+      <button
+        type="button"
+        onClick={() => reset()}
+        className="rounded-full bg-primary px-8 py-3 text-background font-sans text-sm font-medium hover:bg-primary/90 transition-colors"
+      >
+        Try Again
+      </button>
+    </div>
+  );
+}

--- a/nextjs-project/app/properties/loading.tsx
+++ b/nextjs-project/app/properties/loading.tsx
@@ -1,0 +1,69 @@
+/**
+ * Loading skeleton for the properties listing page.
+ * Automatically used by Next.js as a Suspense boundary
+ * while the Server Component data fetches resolve.
+ */
+export default function PropertiesLoading() {
+  return (
+    <div className="animate-pulse">
+      {/* Header skeleton */}
+      <header className="pt-36 pb-16 px-6 lg:px-20">
+        <div className="flex items-center gap-4 mb-6">
+          <div className="w-12 h-px bg-surface/40" />
+          <div className="h-3 w-40 bg-surface/40 rounded" />
+        </div>
+        <div className="space-y-2">
+          <div className="h-[clamp(3rem,12vw,10rem)] w-48 md:w-80 bg-surface/40 rounded" />
+        </div>
+      </header>
+
+      {/* Table skeleton */}
+      <div className="px-6 lg:px-20 pb-40">
+        {/* Header row */}
+        <div className="grid grid-cols-12 py-6 border-b border-white/10">
+          {[1, 5, 3, 3].map((span, i) => (
+            <div
+              key={i}
+              className="h-3 bg-surface/40 rounded"
+              style={{ gridColumn: `span ${span}` }}
+            />
+          ))}
+        </div>
+
+        {/* Property row placeholders */}
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div
+            key={i}
+            className="grid grid-cols-12 py-10 items-center border-b border-white/[0.03]"
+          >
+            <div className="col-span-1">
+              <div className="h-4 w-8 bg-surface/40 rounded" />
+            </div>
+            <div className="col-span-5 space-y-2">
+              <div className="h-8 md:h-12 w-40 md:w-64 bg-surface/40 rounded" />
+              <div className="h-3 w-32 bg-surface/40 rounded" />
+            </div>
+            <div className="col-span-3">
+              <div className="h-4 w-24 bg-surface/40 rounded" />
+            </div>
+            <div className="col-span-3 flex justify-end">
+              <div className="h-6 w-16 bg-surface/40 rounded" />
+            </div>
+          </div>
+        ))}
+
+        {/* Footer skeleton */}
+        <div className="fixed bottom-0 left-0 right-0 bg-background border-t border-white/10 px-6 py-6">
+          <div className="flex gap-10 md:gap-16">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="space-y-1">
+                <div className="h-2 w-16 bg-surface/40 rounded" />
+                <div className="h-3 w-12 bg-surface/40 rounded" />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/nextjs-project/app/properties/page.tsx
+++ b/nextjs-project/app/properties/page.tsx
@@ -1,0 +1,46 @@
+import type { Metadata } from "next";
+import { fetchProperties } from "@/lib/fetch-property";
+import { fetchGlobal } from "@/lib/fetch-global";
+import { getEnv } from "@/lib/env";
+import { PropertyIndex } from "@/components/PropertyIndex";
+
+/** Render at request time — Strapi may not be available during build. */
+export const dynamic = "force-dynamic";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const globalData = await fetchGlobal();
+
+  return {
+    title: `Properties — ${globalData.siteName}`,
+    description:
+      globalData.defaultSeo?.metaDescription ??
+      `Browse our portfolio of exceptional properties.`,
+    openGraph: globalData.defaultSeo?.shareImage
+      ? {
+          images: [
+            {
+              url: `${getEnv().STRAPI_URL}${globalData.defaultSeo.shareImage.url}`,
+            },
+          ],
+        }
+      : undefined,
+  };
+}
+
+/**
+ * Properties listing page — "The Index"
+ *
+ * Ported from the Zenith reference design:
+ *   - Dark aesthetic with headline "THE INDEX"
+ *   - Grid table layout: Ref | Property | Location | Type
+ *   - Hover image reveal that follows the cursor
+ *   - Footer with aggregate portfolio stats
+ *
+ * Data source: Strapi CMS via fetchProperties()
+ */
+export default async function PropertiesPage() {
+  const properties = await fetchProperties();
+  const strapiUrl = getEnv().STRAPI_URL;
+
+  return <PropertyIndex properties={properties} strapiUrl={strapiUrl} />;
+}

--- a/nextjs-project/components/ConditionalNavbar.tsx
+++ b/nextjs-project/components/ConditionalNavbar.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { Navbar } from "@/components/Navbar";
+
+export function ConditionalNavbar() {
+  const pathname = usePathname();
+
+  // Homepage is a full-screen overlay with no nav
+  if (pathname === "/") {
+    return null;
+  }
+
+  return <Navbar />;
+}

--- a/nextjs-project/components/HomeNav.tsx
+++ b/nextjs-project/components/HomeNav.tsx
@@ -2,38 +2,33 @@
 
 import { useState } from "react";
 
-export function Navbar() {
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
+const links = [
+  { label: "Properties", href: "/properties" },
+  { label: "About", href: "/about" },
+  { label: "Contact", href: "/contact" },
+] as const;
 
-  const links = [
-    { label: "Home", href: "/" },
-    { label: "Properties", href: "/properties" },
-    { label: "About", href: "/about" },
-    { label: "Contact", href: "/contact" },
-  ];
+export function HomeNav() {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   return (
     <nav
       role="navigation"
       aria-label="Main navigation"
-      className="fixed top-0 left-0 right-0 z-50"
+      className="absolute top-0 left-0 right-0 z-50"
     >
-      {/* Glass gradient shell */}
       <div className="mx-4 mt-4 rounded-glass-shell bg-gradient-to-br from-white/30 via-white/5 to-transparent p-[1px]">
-        {/* Glass content surface */}
-        <div className="rounded-glass bg-surface/50 backdrop-blur-[4px] px-6 py-4 flex items-center justify-between">
-          {/* Logo */}
-          <span className="font-display text-primary text-lg">
+        <div className="rounded-glass bg-surface/50 backdrop-blur-[4px] shadow-glass px-6 py-4 flex items-center justify-between">
+          <span className="font-display text-primary text-lg tracking-wide">
             Zenith
           </span>
 
-          {/* Desktop nav links */}
           <ul className="hidden md:flex gap-8" role="list">
             {links.map((link) => (
               <li key={link.href}>
                 <a
                   href={link.href}
-                  className="text-secondary/70 hover:text-primary transition-colors text-sm"
+                  className="nav-link text-secondary/70 hover:text-primary transition-colors text-xs uppercase tracking-[0.3em]"
                 >
                   {link.label}
                 </a>
@@ -41,7 +36,6 @@ export function Navbar() {
             ))}
           </ul>
 
-          {/* Mobile hamburger */}
           <button
             className="md:hidden text-secondary/70 hover:text-primary transition-colors"
             aria-label="Toggle navigation menu"
@@ -76,15 +70,14 @@ export function Navbar() {
         </div>
       </div>
 
-      {/* Mobile menu dropdown */}
       {isMenuOpen && (
-        <div className="md:hidden mx-4 mt-1 rounded-glass bg-surface/90 backdrop-blur-[4px] px-6 py-4">
+        <div className="md:hidden mx-4 mt-1 rounded-glass bg-surface/90 backdrop-blur-[4px] shadow-glass px-6 py-4">
           <ul className="flex flex-col gap-4" role="list">
             {links.map((link) => (
               <li key={link.href}>
                 <a
                   href={link.href}
-                  className="text-secondary/70 hover:text-primary transition-colors text-sm block py-1"
+                  className="text-secondary/70 hover:text-primary transition-colors text-xs uppercase tracking-[0.3em] block py-1"
                   onClick={() => setIsMenuOpen(false)}
                 >
                   {link.label}

--- a/nextjs-project/components/MonolithHero.test.tsx
+++ b/nextjs-project/components/MonolithHero.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MonolithHero } from "./MonolithHero";
+
+// Mock next/image
+vi.mock("next/image", () => ({
+  default: (props: { src: string; alt: string; fill?: boolean; priority?: boolean; sizes?: string; className?: string }) =>
+    <img src={props.src} alt={props.alt} data-fill={props.fill ? "true" : undefined} className={props.className} />,
+}));
+
+// Mock next/link
+vi.mock("next/link", () => ({
+  default: ({ href, children, className }: { href: string; children: React.ReactNode; className?: string }) =>
+    <a href={href} className={className}>{children}</a>,
+}));
+
+describe("MonolithHero", () => {
+  it("renders tagline", () => {
+    render(<MonolithHero tagline="Zenith Real Estate" />);
+
+    expect(screen.getByText("Zenith Real Estate")).toBeInTheDocument();
+  });
+
+  it("shows brand headline", () => {
+    render(<MonolithHero tagline="Zenith" />);
+
+    const heading = screen.getByRole("heading", { level: 1 });
+    expect(heading).toHaveTextContent(/Zenith/);
+    expect(heading).toHaveTextContent(/Estates/);
+  });
+
+  it('shows "Access Portfolio" CTA', () => {
+    render(<MonolithHero tagline="Zenith" />);
+
+    const cta = screen.getByRole("link", { name: /access portfolio/i });
+    expect(cta).toBeInTheDocument();
+    expect(cta).toHaveAttribute("href", "/properties");
+  });
+
+  it("renders side brand mark on large screens", () => {
+    render(<MonolithHero tagline="Zenith" />);
+
+    expect(screen.getByText("Z")).toBeInTheDocument();
+    expect(screen.getByText("Curated Estates")).toBeInTheDocument();
+  });
+
+  it("renders description text", () => {
+    render(<MonolithHero tagline="Zenith" />);
+
+    expect(screen.getByText(/Exceptional properties curated/i)).toBeInTheDocument();
+  });
+});

--- a/nextjs-project/components/MonolithHero.tsx
+++ b/nextjs-project/components/MonolithHero.tsx
@@ -1,0 +1,85 @@
+import Image from "next/image";
+import Link from "next/link";
+import type { Property } from "@/lib/schemas/property";
+
+interface MonolithHeroProps {
+  tagline?: string;
+  property?: Property | null;
+  strapiUrl?: string;
+}
+
+export function MonolithHero({ tagline, property, strapiUrl }: MonolithHeroProps) {
+  const heroImageUrl =
+    property?.heroImage && strapiUrl
+      ? `${strapiUrl}${property.heroImage.url}`
+      : null;
+
+  return (
+    <div className="relative h-full w-full flex items-center justify-center overflow-hidden">
+      {/* Background */}
+      {heroImageUrl ? (
+        <Image
+          src={heroImageUrl}
+          alt={property?.heroImage?.alternativeText ?? ""}
+          fill
+          priority
+          sizes="100vw"
+          className="object-cover"
+        />
+      ) : (
+        <div className="absolute inset-0 bg-gradient-to-br from-surface via-background to-background" />
+      )}
+
+      {/* Glass overlay */}
+      <div className="absolute inset-0 bg-gradient-to-t from-background via-background/60 to-background/20 backdrop-blur-[2px]" />
+
+      {/* Side brand mark */}
+      <div className="absolute left-0 top-0 h-full w-20 hidden lg:flex flex-col items-center justify-between py-16 z-20">
+        <div className="font-display text-primary text-2xl tracking-wide">Z</div>
+        <div className="rotate-[-90deg] origin-center whitespace-nowrap text-[8px] tracking-[0.5em] uppercase text-secondary/20">
+          Curated Estates
+        </div>
+        <div className="flex flex-col gap-3">
+          <div className="w-1 h-1 bg-primary rounded-full" />
+          <div className="w-1 h-1 bg-secondary/20 rounded-full" />
+          <div className="w-1 h-1 bg-secondary/20 rounded-full" />
+        </div>
+      </div>
+
+      {/* Centered hero content */}
+      <div className="relative z-10 text-center flex flex-col items-center px-6">
+        {tagline && (
+          <div className="animate-[slideUp_1.2s_cubic-bezier(0.16,1,0.3,1)_forwards] opacity-0 [animation-delay:0.2s]">
+            <span className="text-[10px] uppercase tracking-[0.5em] text-primary/70 mb-6 block">
+              {tagline}
+            </span>
+          </div>
+        )}
+
+        <h1 className="animate-[slideUp_1.2s_cubic-bezier(0.16,1,0.3,1)_forwards] opacity-0 [animation-delay:0.4s] font-display text-[clamp(3.5rem,12vw,12rem)] leading-[0.85] tracking-[-0.03em] text-primary uppercase">
+          <>
+            Zenith<br />Estates
+          </>
+        </h1>
+
+        <div className="mt-10 animate-[slideUp_1.2s_cubic-bezier(0.16,1,0.3,1)_forwards] opacity-0 [animation-delay:0.6s] flex flex-col items-center gap-8">
+          <p className="max-w-md text-xs tracking-[0.25em] leading-loose uppercase text-secondary/40">
+            Exceptional properties curated for the discerning investor. Discover our portfolio of premium real estate.
+          </p>
+
+          <Link
+            href="/properties"
+            className="group relative inline-flex items-center gap-3 px-10 py-4 overflow-hidden rounded-glass bg-primary/10 backdrop-blur-[2px] border border-primary/20 text-primary text-[11px] uppercase tracking-[0.25em] font-medium transition-all duration-700 hover:pl-14 hover:bg-primary hover:text-background"
+          >
+            <span className="relative z-10">
+              Access Portfolio
+            </span>
+            <span className="relative z-10 text-base transition-transform duration-700 group-hover:translate-x-1">
+              →
+            </span>
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/nextjs-project/components/PropertyIndex.tsx
+++ b/nextjs-project/components/PropertyIndex.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import type { Property } from "@/lib/schemas/property";
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+interface PropertyIndexProps {
+  properties: Property[];
+  strapiUrl: string;
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function formatRef(index: number): string {
+  return String(index + 1).padStart(3, "0");
+}
+
+function formatPropertyType(type: string | null): string {
+  if (!type) return "Property";
+  return type
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+// ── Component ───────────────────────────────────────────────────────────────
+
+export function PropertyIndex({ properties, strapiUrl }: PropertyIndexProps) {
+  const [activeImageSrc, setActiveImageSrc] = useState<string | null>(null);
+  const [mousePos, setMousePos] = useState({ x: 0, y: 0 });
+  const [isRevealVisible, setIsRevealVisible] = useState(false);
+
+  const handleMouseMove = (e: React.MouseEvent) => {
+    setMousePos({ x: e.clientX, y: e.clientY });
+  };
+
+  const handleRowEnter = (heroImageUrl: string | null) => {
+    if (heroImageUrl) {
+      setActiveImageSrc(`${strapiUrl}${heroImageUrl}`);
+      setIsRevealVisible(true);
+    }
+  };
+
+  const handleRowLeave = () => {
+    setIsRevealVisible(false);
+  };
+
+  // ── Aggregate stats ───────────────────────────────────────────────────
+
+  const totalAcreage = properties.reduce(
+    (sum, p) => sum + (p.acreage ?? 0),
+    0,
+  );
+  const distinctLocations = new Set(
+    properties.map((p) => p.location).filter(Boolean),
+  ).size;
+  const hasProperties = properties.length > 0;
+
+  // ── Render ─────────────────────────────────────────────────────────────
+
+  return (
+    <>
+      {/* Header */}
+      <header className="pt-36 pb-16 px-6 lg:px-20 relative z-10">
+        <div className="font-sans text-[10px] tracking-[0.5em] text-primary/50 mb-6 uppercase flex items-center gap-4">
+          <div className="w-12 h-px bg-primary/50" /> Portfolio_Holdings
+        </div>
+        <h1 className="font-display text-[clamp(3rem,12vw,10rem)] leading-[0.8] tracking-[-0.05em] font-black uppercase text-primary">
+          THE
+          <br />
+          INDEX.
+        </h1>
+      </header>
+
+      {/* Properties List */}
+      <main
+        className="px-6 lg:px-20 pb-40 relative"
+        onMouseMove={handleMouseMove}
+      >
+        {/* Table Headers — hidden when no properties */}
+        {hasProperties && (
+          <div className="grid grid-cols-12 py-6 border-b border-white/10 font-sans text-[9px] uppercase tracking-[0.3em] text-secondary/30">
+            <div className="col-span-1">Ref</div>
+            <div className="col-span-5">Property</div>
+            <div className="col-span-3">Location</div>
+            <div className="col-span-3 text-right">Type</div>
+          </div>
+        )}
+
+        {/* Empty state */}
+        {!hasProperties && (
+          <div className="py-32 text-center">
+            <p className="font-display text-3xl md:text-5xl text-primary/30">
+              No properties yet.
+            </p>
+            <p className="mt-4 font-sans text-sm text-secondary/40 uppercase tracking-widest">
+              The portfolio is being curated — check back soon.
+            </p>
+          </div>
+        )}
+
+        {/* Property Rows */}
+        {properties.map((property, index) => (
+          <Link
+            key={property.documentId}
+            href={`/properties/${property.slug}`}
+            className="index-row grid grid-cols-12 py-10 items-center border-b border-primary/10 transition-all duration-500 ease-[cubic-bezier(0.16,1,0.3,1)] cursor-pointer relative z-10 hover:bg-primary/[0.03] hover:pl-5 hover:border-primary/40 group"
+            onMouseEnter={() =>
+              handleRowEnter(property.heroImage?.url ?? null)
+            }
+            onMouseLeave={handleRowLeave}
+          >
+            {/* Ref */}
+            <div className="col-span-1 font-sans text-xs text-primary/50 font-bold">
+              {formatRef(index)}
+            </div>
+
+            {/* Asset Identity */}
+            <div className="col-span-5">
+              <h2 className="text-2xl md:text-5xl font-display font-black uppercase tracking-tighter text-primary group-hover:text-primary transition-colors">
+                {property.title}
+              </h2>
+              <p className="font-sans text-[9px] text-secondary/40 uppercase tracking-widest mt-1">
+                {formatPropertyType(property.propertyType)}
+                {property.acreage ? ` / ${property.acreage} acres` : ""}
+              </p>
+            </div>
+
+            {/* Location */}
+            <div className="col-span-3">
+              <p className="font-sans text-xs uppercase tracking-widest text-secondary/60">
+                {property.location ?? "—"}
+              </p>
+            </div>
+
+            {/* Type */}
+            <div className="col-span-3 text-right">
+              <p className="text-xl font-bold tracking-tighter text-secondary/80">
+                {property.propertyType
+                  ? formatPropertyType(property.propertyType)
+                  : "—"}
+              </p>
+            </div>
+          </Link>
+        ))}
+
+        {/* Hover Image Reveal */}
+        <div
+          aria-hidden="true"
+          className="fixed w-[250px] md:w-[400px] h-[300px] md:h-[500px] pointer-events-none z-[5] overflow-hidden transition-all duration-500 ease-[cubic-bezier(0.16,1,0.3,1)] grayscale contrast-125 hidden md:block"
+          style={{
+            left: `${mousePos.x}px`,
+            top: `${mousePos.y}px`,
+            opacity: isRevealVisible ? 0.6 : 0,
+            transform: `translate(-50%, -50%) scale(${isRevealVisible ? 1 : 0.8})`,
+          }}
+        >
+          {activeImageSrc && (
+            <Image
+              src={activeImageSrc}
+              alt=""
+              fill
+              sizes="400px"
+              className="object-cover"
+              unoptimized
+            />
+          )}
+        </div>
+      </main>
+
+      {/* Footer Stats */}
+      {hasProperties && (
+        <footer
+          role="contentinfo"
+          className="fixed bottom-0 w-full bg-background border-t border-white/10 px-6 py-6 flex justify-between items-center z-[110]"
+        >
+          <div className="flex gap-10 md:gap-16">
+            <div>
+              <p className="font-sans text-[8px] text-secondary/30 uppercase mb-1 tracking-widest">
+                Holdings
+              </p>
+              <p className="font-sans text-xs text-secondary font-bold">
+                {properties.length}{" "}
+                {properties.length === 1 ? "Property" : "Properties"}
+              </p>
+            </div>
+            <div>
+              <p className="font-sans text-[8px] text-secondary/30 uppercase mb-1 tracking-widest">
+                Aggregate_Acreage
+              </p>
+              <p className="font-sans text-xs text-secondary font-bold">
+                {totalAcreage.toLocaleString()}{" "}
+                {totalAcreage === 1 ? "acre" : "acres"}
+              </p>
+            </div>
+            <div>
+              <p className="font-sans text-[8px] text-secondary/30 uppercase mb-1 tracking-widest">
+                Locations
+              </p>
+              <p className="font-sans text-xs text-secondary font-bold">
+                {distinctLocations}{" "}
+                {distinctLocations === 1 ? "Location" : "Locations"}
+              </p>
+            </div>
+          </div>
+          <div className="hidden md:block text-[10px] font-sans text-secondary/20 uppercase tracking-[0.4em]">
+            Zenith Holdings / Private Index
+          </div>
+        </footer>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Add /properties route with loading and error states
- Add HomeNav component for conditional navbar behavior
- Add MonolithHero component with tests
- Add PropertyIndex component
- Add ConditionalNavbar component
- Simplify homepage tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Launched a Properties page with browsable property listings and interactive hover previews
  * Added loading skeleton screens for better perceived performance
  * Implemented error handling with recovery options for properties
  * Introduced slide-up animation effects throughout the site
  * Conditional navigation now hides navbar on homepage for a cleaner brand experience

* **Style**
  * Refined spacing on About and Contact pages
  * Removed shadow effect from navigation bar

* **Tests**
  * Added test coverage for new hero component

<!-- end of auto-generated comment: release notes by coderabbit.ai -->