### PR TITLE
feat: refresh hero and Emri Village banner copy, fix About page 403

### DIFF
--- a/nextjs-project/components/DevelopmentComingSoon.tsx
+++ b/nextjs-project/components/DevelopmentComingSoon.tsx
@@ -12,10 +12,10 @@ export function DevelopmentComingSoon() {
               </div>
               <div>
                 <h3 className="font-sans text-sm font-black uppercase tracking-[0.2em] text-primary mb-1">
-                  Master Plan in Progress
+                  Emri Village — Private Preview
                 </h3>
                 <p className="font-sans text-[10px] uppercase tracking-[0.05em] leading-loose text-secondary/40">
-                  Emri Village is being elevated to a luxury standard. Plot availability coming soon.
+                  Premium lots within Emri Village, developed to a new standard. Availability is limited — join the waitlist for priority access.
                 </p>
               </div>
             </div>

--- a/nextjs-project/components/MonolithHero.test.tsx
+++ b/nextjs-project/components/MonolithHero.test.tsx
@@ -48,6 +48,10 @@ describe("MonolithHero", () => {
   it("renders description text", () => {
     render(<MonolithHero tagline="Real Assets. Digital Future." />);
 
-    expect(screen.getByText(/Real estate built for the century ahead/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Premium real estate\. On-chain liquidity\. Property that trades like any asset should\./i
+      )
+    ).toBeInTheDocument();
   });
 });

--- a/nextjs-project/components/MonolithHero.tsx
+++ b/nextjs-project/components/MonolithHero.tsx
@@ -15,7 +15,7 @@ export function MonolithHero({
   property,
   strapiUrl,
   headline = "DISRUPT\nTHE BLOCK",
-  description = "Real estate built for the century ahead. We pair premium properties with the infrastructure to bring assets on chain so land is as easy to trade as anything else.",
+  description = "Premium real estate. On-chain liquidity. Property that trades like any asset should.",
 }: MonolithHeroProps) {
   const heroImageUrl =
     property?.heroImage?.url

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -100,6 +100,11 @@ export default {
     // Only seed in development
     if (process.env.NODE_ENV !== 'development') return;
 
+    // Always ensure public permissions exist in development.
+    // About can be added after initial seed, so permissions must not depend
+    // on property seed state.
+    await setPublicPermissions(strapi);
+
     // Check if already seeded
     const existingProperties = await strapi.documents('api::property.property').findMany({});
     if (existingProperties.length > 0) {
@@ -113,8 +118,6 @@ export default {
       await seedProperty(strapi);
       await seedSubmission(strapi);
       await seedGlobal(strapi);
-      // Also set public permissions
-      await setPublicPermissions(strapi);
       console.log('Seed complete!');
     } catch (error) {
       console.error('Seed failed:', error);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -103,7 +103,11 @@ export default {
     // Always ensure public permissions exist in development.
     // About can be added after initial seed, so permissions must not depend
     // on property seed state.
-    await setPublicPermissions(strapi);
+    try {
+      await setPublicPermissions(strapi);
+    } catch (error) {
+      console.error('Failed to set public permissions:', error);
+    }
 
     // Check if already seeded
     const existingProperties = await strapi.documents('api::property.property').findMany({});


### PR DESCRIPTION
## Changes

### Copy Updates
- **MonolithHero**: Description updated to concise three-line variant: Premium real estate. On-chain liquidity. Property that trades like any asset should.
- **Emri Village banner**: Reframed from construction status to private preview, scoped to our lots (not the whole village). Headline: Emri Village - Private Preview. Description: Premium lots within Emri Village, developed to a new standard. Availability is limited - join the waitlist for priority access.

### Bug Fix
- **Strapi bootstrap**: Moved setPublicPermissions() to run before seed early-return so About API permissions are always set and no longer return 403.

## Files Changed
- nextjs-project/components/MonolithHero.tsx
- nextjs-project/components/DevelopmentComingSoon.tsx
- server/src/index.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated messaging to announce the Emri Village private preview, highlight limited premium lot availability, and encourage waitlist registration.
  * Refined hero messaging to emphasize premium real estate, on-chain liquidity, and asset-like property trading.

* **Bug Fixes**
  * Public access permissions are now applied reliably during development, including when property seeding is skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->